### PR TITLE
Update tools.py

### DIFF
--- a/weaver/utils/data/tools.py
+++ b/weaver/utils/data/tools.py
@@ -113,7 +113,7 @@ def _p4_from_ptetaphie(pt, eta, phi, energy):
 def _p4_from_ptetaphim(pt, eta, phi, mass):
     import vector
     vector.register_awkward()
-    return vector.Array({'pt': pt, 'eta': eta, 'phi': phi, 'mass': mass})
+    return vector.zip({'pt': pt, 'eta': eta, 'phi': phi, 'mass': mass})
 
 
 def _get_variable_names(expr, exclude=['awkward', 'ak', 'np', 'numpy', 'math']):


### PR DESCRIPTION
Days ago when I tried to run a train, this line(https://github.com/hqucms/weaver-core/blob/646a9408b776e7dcf9c21324ff2b28153b472162/weaver/utils/data/tools.py#L116 ) raised an error saying 'a coordinate must be of the type int or float' .

I found a discussion about this very problem here: https://gitter.im/Scikit-HEP/vector . Like documented in this discussion, it turns out to be the difference between 'vector' module, in version 0.8.5 it's fine but version 0.9.0 and later adds a type-check. 

Anyway using 'vector.zip' still works. I don't know whether https://github.com/hqucms/weaver-core/blob/646a9408b776e7dcf9c21324ff2b28153b472162/weaver/utils/data/tools.py#L110 and https://github.com/hqucms/weaver-core/blob/646a9408b776e7dcf9c21324ff2b28153b472162/weaver/utils/data/tools.py#L101 will raise the same error since they also used 'vector.Array' but I didn't met the same problem. I can make another pull request when I confirm it.