### PR TITLE
use absolute value of pz to protect against minus infinity for rapidity

### DIFF
--- a/weaver/nn/model/ParticleTransformer.py
+++ b/weaver/nn/model/ParticleTransformer.py
@@ -50,7 +50,7 @@ def to_ptrapphim(x, return_mass=True, eps=1e-8, for_onnx=False):
     px, py, pz, energy = x.split((1, 1, 1, 1), dim=1)
     pt = torch.sqrt(to_pt2(x, eps=eps))
     # rapidity = 0.5 * torch.log((energy + pz) / (energy - pz))
-    rapidity = 0.5 * torch.log(1 + (2 * pz) / (energy - pz).clamp(min=1e-20))
+    rapidity = 0.5 * pz.sign() * torch.log(1 + (2 * pz.abs()) / (energy - pz.abs()).clamp(min=1e-20))
     phi = (atan2 if for_onnx else torch.atan2)(py, px)
     if not return_mass:
         return torch.cat((pt, rapidity, phi), dim=1)


### PR DESCRIPTION
Thanks for providing this code! I started playing a bit with the ParticleTransformer and ran into an issue of getting negative infinite values when pz is negative and very close in magnitude to the energy. The current implementation for calculating the rapidity protects against positive pz being close to energy, but not negative ones. This PR suggests using the absolute value and multiplying by the sign afterwards.

```python
def rapidity_old(energy, pz):
    return 0.5 * torch.log(1 + (2 * pz) / (energy - pz).clamp(min=1e-20))
    
def rapidity_new(energy, pz):
    return 0.5 * pz.sign() * torch.log(1 + (2 * pz.abs()) / (energy - pz.abs()).clamp(min=1e-20))
```

```pycon
>>> import torch
>>> rapidity_old(torch.tensor(10.), torch.tensor(9.))
tensor(1.4722)
>>> rapidity_old(torch.tensor(10.), torch.tensor(10.))
tensor(24.5237)
>>> rapidity_old(torch.tensor(10.), torch.tensor(-9.))
tensor(-1.4722)
>>> rapidity_old(torch.tensor(10.), torch.tensor(-9.9999999))
tensor(-inf)
>>> rapidity_old(torch.tensor(10.), torch.tensor(-10.))
tensor(-inf)
>>>
>>> rapidity_new(torch.tensor(10.), torch.tensor(9.))
tensor(1.4722)
>>> rapidity_new(torch.tensor(10.), torch.tensor(10.))
tensor(24.5237)
>>> rapidity_new(torch.tensor(10.), torch.tensor(-9.))
tensor(-1.4722)
>>> rapidity_new(torch.tensor(10.), torch.tensor(-9.9999999))
tensor(-24.5237)
>>> rapidity_new(torch.tensor(10.), torch.tensor(-10.))
tensor(-24.5237)
```