### PR TITLE
fix cpu/gpu switch

### DIFF
--- a/weaver/train.py
+++ b/weaver/train.py
@@ -733,7 +733,7 @@ def _main(args):
     training_mode = not args.predict
 
     # device
-    if args.gpus:
+    if int(args.gpus):
         # distributed training
         if args.backend is not None:
             local_rank = args.local_rank


### PR DESCRIPTION
args.gpus="0" was considered as a string and not as an integer, resulting to the use of GPU