### PR TITLE
Adding new utilities

### DIFF
--- a/weaver/train.py
+++ b/weaver/train.py
@@ -147,10 +147,8 @@ parser.add_argument('--io-test', action='store_true', default=False,
                     help='test throughput of the dataloader')
 parser.add_argument('--copy-inputs', action='store_true', default=False,
                     help='copy input files to the current dir (can help to speed up dataloading when running over remote files, e.g., from EOS)')
-parser.add_argument('--log', type=str, default='',
+parser.add_argument('--log-f', type=str, dest='log', default='',
                     help='path to the log file; `{auto}` can be used as part of the path to auto-generate a name, based on the timestamp and network configuration')
-parser.add_argument('--log-file', type=str, default='',
-                    help='same with --log; avoid conflict with the torchrun argument')
 parser.add_argument('--print', action='store_true', default=False,
                     help='do not run training/prediction but only print model information, e.g., FLOPs and number of parameters of a model')
 parser.add_argument('--profile', action='store_true', default=False,
@@ -986,11 +984,6 @@ def main():
     if args.custom_functions is not None:
         func_module = import_module(args.custom_functions, '_func_module')
         _register_funcs(func_module)
-
-    if args.log_file:
-        if args.log:
-            raise RuntimeError('Please use either `--log-file` or `--log`, but not both')
-        args.log = args.log_file
 
     if '{auto}' in args.model_prefix or '{auto}' in args.log:
         import hashlib

--- a/weaver/utils/dataset.py
+++ b/weaver/utils/dataset.py
@@ -131,8 +131,8 @@ def _preprocess(table, data_config, options):
 
 def _load_next(data_config, filelist, split_num_info, load_range, options):
     load_branches = data_config.train_load_branches if options['training'] else data_config.test_load_branches
-    split_num, split_tot_num = split_num_info
-    filelist = filelist[split_num::split_tot_num]
+    i_split, split_num = split_num_info
+    filelist = filelist[i_split::split_num]
     table = _read_files(filelist, load_branches, load_range, treename=data_config.treename,
                         branch_magic=data_config.branch_magic, file_magic=data_config.file_magic)
     table, indices = _preprocess(table, data_config, options)

--- a/weaver/utils/dataset.py
+++ b/weaver/utils/dataset.py
@@ -278,7 +278,7 @@ class _SimpleIter(object):
             load_range = (self.ipos, min(self.ipos + self._fetch_step, self.load_range[1]))
         split_num_info = (self.isplit, self.split_num)
 
-        _logger.info('Start fetching next batch, len(filelist)=%d (split by %d), split_num_info=%s, load_range=%s'%(len(filelist), self.split_num, split_num_info, load_range))
+        # _logger.info('Start fetching next batch, len(filelist)=%d (split by %d), split_num_info=%s, load_range=%s'%(len(filelist), self.split_num, split_num_info, load_range))
         if self._async_load:
             self.prefetch = self.executor.submit(_load_next, self._data_config,
                                                  filelist, split_num_info, load_range, self._sampler_options)


### PR DESCRIPTION
- specify `--log-file` as an alternative to `--log` to avoid conflicting with torchrun.
- add `--data-split-num`: for each dataloader worker, split its dataset further into N parts when loading a certain fraction of each file. Setting N > 1 can reduce the workers' memory usage.