### PR TITLE
Add --run-mode and update flops_counter

### DIFF
--- a/weaver/train.py
+++ b/weaver/train.py
@@ -780,7 +780,10 @@ def _main(args):
         _logger.warning('Use of `file-fraction` is not recommended in general -- prefer using `data-fraction` instead.')
 
     # training/testing mode
-    training_mode = not args.predict
+    if args.predict:
+        _logger.warning('The `--predict` flag is set. Overriding the `--run-mode` to `test`.')
+        args.run_mode = ['test']
+    training_mode = any(m in args.run_mode for m in ['train', 'val'])
 
     # device
     if args.gpus:

--- a/weaver/utils/data/config.py
+++ b/weaver/utils/data/config.py
@@ -154,9 +154,9 @@ class DataConfig(object):
         self.z_variables = self.observer_names if len(self.observer_names) > 0 else self.monitor_variables
 
         # remove self mapping from var_funcs
-        for k, v in self.var_funcs.items():
-            if k == v:
-                del self.var_funcs[k]
+        var_funcs_self_mapping = [k for k, v in self.var_funcs.items() if k == v]
+        for k in var_funcs_self_mapping:
+            del self.var_funcs[k]
 
         if print_info:
             def _log(msg, *args, **kwargs):

--- a/weaver/utils/dataset.py
+++ b/weaver/utils/dataset.py
@@ -256,7 +256,7 @@ class _SimpleIter(object):
         return self.get_data(i)
 
     def _try_get_next(self, init=False):
-        end_of_list = self.ipos >= len(self.filelist) if self._fetch_by_files else self.ipos >= self.load_range[1]
+        end_of_list = self.ipos >= len(self.filelist) if self._fetch_by_files else self.ipos >= self.load_range[1] - 1e-6
         if end_of_list:
             if init:
                 raise RuntimeError('Nothing to load for worker %d' %

--- a/weaver/utils/flops_counter.py
+++ b/weaver/utils/flops_counter.py
@@ -7,11 +7,14 @@ Copyright (C) 2019 Sovrasov V. - All Rights Reserved
 '''
 
 import sys
+import traceback
 from functools import partial
+from typing import Dict, Optional, Tuple, Union
 
 import numpy as np
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 
 from .logger import _logger
 
@@ -23,8 +26,12 @@ def get_model_complexity_info(model, inputs,
                               as_strings=True,
                               ost=sys.stdout,
                               verbose=False, ignore_modules=[],
-                              custom_modules_hooks={}):
-    assert isinstance(model, nn.Module)
+                              custom_modules_hooks={},
+                              output_precision=3,
+                              flops_units: Optional[str] = None,
+                              param_units: Optional[str] = 'M',
+                              extra_config: Dict = {}) -> Tuple[Union[int, None],
+                                                                Union[int, None]]:
     global CUSTOM_MODULES_MAPPING
     CUSTOM_MODULES_MAPPING = custom_modules_hooks
     flops_model = add_flops_counting_methods(model)
@@ -32,13 +39,46 @@ def get_model_complexity_info(model, inputs,
     flops_model.start_flops_count(ost=ost, verbose=verbose,
                                   ignore_list=ignore_modules)
 
-    _ = flops_model(*inputs)
+    enable_func_ops_patching = extra_config.get('count_functional', True)
+    torch_functional_flops = []
+    torch_tensor_ops_flops = []
+    if enable_func_ops_patching:
+        patch_functional(torch_functional_flops)
+        patch_tensor_ops(torch_tensor_ops_flops)
 
-    flops_count, params_count = flops_model.compute_average_flops_cost()
+    def reset_environment():
+        flops_model.stop_flops_count()
+        if enable_func_ops_patching:
+            unpatch_functional()
+            unpatch_tensor_ops()
+        global CUSTOM_MODULES_MAPPING
+        CUSTOM_MODULES_MAPPING = {}
+
+    try:
+        _ = flops_model(*inputs)
+        flops_count, params_count = flops_model.compute_average_flops_cost()
+        flops_count += sum(torch_functional_flops)
+        flops_count += sum(torch_tensor_ops_flops)
+
+    except Exception as e:
+        _logger.info("Flops estimation was not finished successfully because of"
+              f" the following exception:\n{type(e)} : {e}")
+        traceback.print_exc()
+        reset_environment()
+
+        return None, None
+
     if print_per_layer_stat:
-        print_model_with_flops(flops_model, flops_count, params_count, ost=ost)
-    flops_model.stop_flops_count()
-    CUSTOM_MODULES_MAPPING = {}
+        print_model_with_flops(
+            flops_model,
+            flops_count,
+            params_count,
+            ost=ost,
+            flops_units=flops_units,
+            param_units=param_units,
+            precision=output_precision
+        )
+    reset_environment()
 
     if as_strings:
         return flops_to_string(flops_count), params_to_string(params_count)
@@ -46,7 +86,15 @@ def get_model_complexity_info(model, inputs,
     return flops_count, params_count
 
 
-def flops_to_string(flops, units=None, precision=2):
+def flops_to_string(flops: int, units: Optional[str] = None, precision: int = 2) -> str:
+    """
+    Converts integer MACs representation to a readable string.
+
+    :param flops: Input MACs.
+    :param units: Units for string representation of MACs (GMac, MMac or KMac).
+    :param precision: Floating point precision for representing MACs in
+        given units.
+    """
     if units is None:
         if flops // 10**9 > 0:
             return str(round(flops / 10.**9, precision)) + ' GMac'
@@ -67,12 +115,21 @@ def flops_to_string(flops, units=None, precision=2):
             return str(flops) + ' Mac'
 
 
-def params_to_string(params_num, units=None, precision=2):
+def params_to_string(params_num: int, units: Optional[str] = None,
+                     precision: int = 2) -> str:
+    """
+    Converts integer params representation to a readable string.
+
+    :param flops: Input number of parameters.
+    :param units: Units for string representation of params (M, K or B).
+    :param precision: Floating point precision for representing params in
+        given units.
+    """
     if units is None:
         if params_num // 10 ** 6 > 0:
-            return str(round(params_num / 10 ** 6, 2)) + ' M'
+            return str(round(params_num / 10 ** 6, precision)) + ' M'
         elif params_num // 10 ** 3:
-            return str(round(params_num / 10 ** 3, 2)) + ' k'
+            return str(round(params_num / 10 ** 3, precision)) + ' k'
         else:
             return str(params_num)
     else:
@@ -80,6 +137,8 @@ def params_to_string(params_num, units=None, precision=2):
             return str(round(params_num / 10.**6, precision)) + ' ' + units
         elif units == 'K':
             return str(round(params_num / 10.**3, precision)) + ' ' + units
+        elif units == 'B':
+            return str(round(params_num / 10.**9, precision)) + ' ' + units
         else:
             return str(params_num)
 
@@ -94,10 +153,14 @@ def accumulate_flops(self):
         return sum
 
 
-def print_model_with_flops(model, total_flops, total_params, units=None,
+def print_model_with_flops(model, total_flops, total_params,
+                           flops_units: Optional[str] = 'GMac',
+                           param_units: Optional[str] = 'M',
                            precision=3, ost=sys.stdout):
     if total_flops < 1:
         total_flops = 1
+    if total_params < 1:
+        total_params = 1
 
     def accumulate_params(self):
         if is_supported_instance(self):
@@ -111,11 +174,16 @@ def print_model_with_flops(model, total_flops, total_params, units=None,
     def flops_repr(self):
         accumulated_params_num = self.accumulate_params()
         accumulated_flops_cost = self.accumulate_flops() / model.__batch_counter__
+        if accumulated_params_num > total_params:
+            _logger.info('Warning: parameters of some of the modules were counted twice because'
+                  ' of multiple links to the same modules.'
+                  ' Extended per layer parameters num statistic could be unreliable.')
+
         prefix = self.original_extra_repr() + ', |' if self.original_extra_repr() else '|'
         return prefix + ', '.join([
-            params_to_string(accumulated_params_num, units='M', precision=precision),
+            params_to_string(accumulated_params_num, units=param_units, precision=precision),
             '{:.3%} Params'.format(accumulated_params_num / total_params),
-            flops_to_string(accumulated_flops_cost, units=units, precision=precision),
+            flops_to_string(accumulated_flops_cost, units=flops_units, precision=precision),
             '{:.3%} MACs'.format(accumulated_flops_cost / total_flops)]) + '|'
 
     def add_extra_repr(m):
@@ -229,6 +297,7 @@ def stop_flops_count(self):
     """
     remove_batch_counter_hook_function(self)
     self.apply(remove_flops_counter_hook_function)
+    self.apply(remove_flops_counter_variables)
 
 
 def reset_flops_count(self):
@@ -241,6 +310,217 @@ def reset_flops_count(self):
     """
     add_batch_counter_variables_or_reset(self)
     self.apply(add_flops_counter_variable_or_reset)
+
+
+# ---- Internal functions
+def batch_counter_hook(module, input, output):
+    batch_size = 1
+    if len(input) > 0:
+        # Can have multiple inputs, getting the first one
+        input = input[0]
+        batch_size = len(input)
+    else:
+        pass
+        _logger.info('Warning! No positional inputs found for a module,'
+              ' assuming batch size is 1.')
+    module.__batch_counter__ += batch_size
+
+
+def add_batch_counter_variables_or_reset(module):
+
+    module.__batch_counter__ = 0
+
+
+def add_batch_counter_hook_function(module):
+    if hasattr(module, '__batch_counter_handle__'):
+        return
+
+    handle = module.register_forward_hook(batch_counter_hook)
+    module.__batch_counter_handle__ = handle
+
+
+def remove_batch_counter_hook_function(module):
+    if hasattr(module, '__batch_counter_handle__'):
+        module.__batch_counter_handle__.remove()
+        del module.__batch_counter_handle__
+
+
+def add_flops_counter_variable_or_reset(module):
+    if is_supported_instance(module):
+        if hasattr(module, '__flops__') or hasattr(module, '__params__'):
+            _logger.info('Warning: variables __flops__ or __params__ are already '
+                  'defined for the module' + type(module).__name__ +
+                  ' ptflops can affect your code!')
+            module.__ptflops_backup_flops__ = module.__flops__
+            module.__ptflops_backup_params__ = module.__params__
+        module.__flops__ = 0
+        module.__params__ = get_model_parameters_number(module)
+
+
+def is_supported_instance(module):
+    if type(module) in MODULES_MAPPING or type(module) in CUSTOM_MODULES_MAPPING:
+        return True
+    return False
+
+
+def remove_flops_counter_hook_function(module):
+    if is_supported_instance(module):
+        if hasattr(module, '__flops_handle__'):
+            module.__flops_handle__.remove()
+            del module.__flops_handle__
+
+
+def remove_flops_counter_variables(module):
+    if is_supported_instance(module):
+        if hasattr(module, '__flops__'):
+            del module.__flops__
+            if hasattr(module, '__ptflops_backup_flops__'):
+                module.__flops__ = module.__ptflops_backup_flops__
+        if hasattr(module, '__params__'):
+            del module.__params__
+            if hasattr(module, '__ptflops_backup_params__'):
+                module.__params__ = module.__ptflops_backup_params__
+
+
+class torch_function_wrapper:
+    def __init__(self, op, handler, collector) -> None:
+        self.collector = collector
+        self.op = op
+        self.handler = handler
+
+    def __call__(self, *args, **kwds):
+        flops = self.handler(*args, **kwds)
+        self.collector.append(flops)
+        return self.op(*args, **kwds)
+
+
+def patch_functional(collector):
+    # F.linear = torch_function_wrapper(F.linear, FUNCTIONAL_MAPPING[F.linear], collector)
+    F.relu = torch_function_wrapper(F.relu, FUNCTIONAL_MAPPING[F.relu], collector)
+    F.prelu = torch_function_wrapper(F.prelu, FUNCTIONAL_MAPPING[F.prelu], collector)
+    F.elu = torch_function_wrapper(F.elu, FUNCTIONAL_MAPPING[F.elu], collector)
+    F.relu6 = torch_function_wrapper(F.relu6, FUNCTIONAL_MAPPING[F.relu6], collector)
+    F.gelu = torch_function_wrapper(F.gelu, FUNCTIONAL_MAPPING[F.gelu], collector)
+
+    F.avg_pool1d = torch_function_wrapper(F.avg_pool1d,
+                                          FUNCTIONAL_MAPPING[F.avg_pool1d], collector)
+    F.avg_pool2d = torch_function_wrapper(F.avg_pool2d,
+                                          FUNCTIONAL_MAPPING[F.avg_pool2d], collector)
+    F.avg_pool3d = torch_function_wrapper(F.avg_pool3d,
+                                          FUNCTIONAL_MAPPING[F.avg_pool3d], collector)
+    F.max_pool1d = torch_function_wrapper(F.max_pool1d,
+                                          FUNCTIONAL_MAPPING[F.max_pool1d], collector)
+    F.max_pool2d = torch_function_wrapper(F.max_pool2d,
+                                          FUNCTIONAL_MAPPING[F.max_pool2d], collector)
+    F.max_pool3d = torch_function_wrapper(F.max_pool3d,
+                                          FUNCTIONAL_MAPPING[F.max_pool3d], collector)
+    F.adaptive_avg_pool1d = torch_function_wrapper(
+        F.adaptive_avg_pool1d, FUNCTIONAL_MAPPING[F.adaptive_avg_pool1d], collector)
+    F.adaptive_avg_pool2d = torch_function_wrapper(
+        F.adaptive_avg_pool2d, FUNCTIONAL_MAPPING[F.adaptive_avg_pool2d], collector)
+    F.adaptive_avg_pool3d = torch_function_wrapper(
+        F.adaptive_avg_pool3d, FUNCTIONAL_MAPPING[F.adaptive_avg_pool3d], collector)
+    F.adaptive_max_pool1d = torch_function_wrapper(
+        F.adaptive_max_pool1d, FUNCTIONAL_MAPPING[F.adaptive_max_pool1d], collector)
+    F.adaptive_max_pool2d = torch_function_wrapper(
+        F.adaptive_max_pool2d, FUNCTIONAL_MAPPING[F.adaptive_max_pool2d], collector)
+    F.adaptive_max_pool3d = torch_function_wrapper(
+        F.adaptive_max_pool3d, FUNCTIONAL_MAPPING[F.adaptive_max_pool3d], collector)
+
+    F.softmax = torch_function_wrapper(
+        F.softmax, FUNCTIONAL_MAPPING[F.softmax], collector)
+
+    F.upsample = torch_function_wrapper(
+        F.upsample, FUNCTIONAL_MAPPING[F.upsample], collector)
+    F.interpolate = torch_function_wrapper(
+        F.interpolate, FUNCTIONAL_MAPPING[F.interpolate], collector)
+
+    if hasattr(F, "silu"):
+        F.silu = torch_function_wrapper(F.silu, FUNCTIONAL_MAPPING[F.silu], collector)
+
+
+def unpatch_functional():
+    # F.linear = F.linear.op
+    F.relu = F.relu.op
+    F.prelu = F.prelu.op
+    F.elu = F.elu.op
+    F.relu6 = F.relu6.op
+    F.gelu = F.gelu.op
+    if hasattr(F, "silu"):
+        F.silu = F.silu.op
+
+    F.avg_pool1d = F.avg_pool1d.op
+    F.avg_pool2d = F.avg_pool2d.op
+    F.avg_pool3d = F.avg_pool3d.op
+    F.max_pool1d = F.max_pool1d.op
+    F.max_pool2d = F.max_pool2d.op
+    F.max_pool3d = F.max_pool3d.op
+    F.adaptive_avg_pool1d = F.adaptive_avg_pool1d.op
+    F.adaptive_avg_pool2d = F.adaptive_avg_pool2d.op
+    F.adaptive_avg_pool3d = F.adaptive_avg_pool3d.op
+    F.adaptive_max_pool1d = F.adaptive_max_pool1d.op
+    F.adaptive_max_pool2d = F.adaptive_max_pool2d.op
+    F.adaptive_max_pool3d = F.adaptive_max_pool3d.op
+
+    F.softmax = F.softmax.op
+
+    F.upsample = F.upsample.op
+    F.interpolate = F.interpolate.op
+
+
+def wrap_tensor_op(op, collector):
+    tensor_op_handler = torch_function_wrapper(
+        op, TENSOR_OPS_MAPPING[op], collector)
+
+    def wrapper(*args, **kwargs):
+        return tensor_op_handler(*args, **kwargs)
+
+    wrapper.op = tensor_op_handler.op
+
+    return wrapper
+
+
+def patch_tensor_ops(collector):
+    torch.matmul = torch_function_wrapper(
+        torch.matmul, TENSOR_OPS_MAPPING[torch.matmul], collector)
+    torch.Tensor.matmul = wrap_tensor_op(torch.Tensor.matmul, collector)
+    torch.mm = torch_function_wrapper(
+        torch.mm, TENSOR_OPS_MAPPING[torch.mm], collector)
+    torch.Tensor.mm = wrap_tensor_op(torch.Tensor.mm, collector)
+    torch.bmm = torch_function_wrapper(
+        torch.bmm, TENSOR_OPS_MAPPING[torch.bmm], collector)
+    torch.Tensor.bmm = wrap_tensor_op(torch.Tensor.bmm, collector)
+
+    torch.addmm = torch_function_wrapper(
+        torch.addmm, TENSOR_OPS_MAPPING[torch.addmm], collector)
+    torch.Tensor.addmm = wrap_tensor_op(torch.Tensor.addmm, collector)
+    torch.baddbmm = torch_function_wrapper(
+        torch.baddbmm, TENSOR_OPS_MAPPING[torch.baddbmm], collector)
+
+    torch.mul = torch_function_wrapper(
+        torch.mul, TENSOR_OPS_MAPPING[torch.mul], collector)
+    torch.Tensor.mul = wrap_tensor_op(torch.Tensor.mul, collector)
+    torch.add = torch_function_wrapper(
+        torch.add, TENSOR_OPS_MAPPING[torch.add], collector)
+    torch.Tensor.add = wrap_tensor_op(torch.Tensor.add, collector)
+
+
+def unpatch_tensor_ops():
+    torch.matmul = torch.matmul.op
+    torch.Tensor.matmul = torch.Tensor.matmul.op
+    torch.mm = torch.mm.op
+    torch.Tensor.mm = torch.Tensor.mm.op
+    torch.bmm = torch.bmm.op
+    torch.Tensor.bmm = torch.Tensor.bmm.op
+
+    torch.addmm = torch.addmm.op
+    torch.Tensor.addmm = torch.Tensor.addmm.op
+    torch.baddbmm = torch.baddbmm.op
+
+    torch.mul = torch.mul.op
+    torch.Tensor.mul = torch.Tensor.mul.op
+    torch.add = torch.add.op
+    torch.Tensor.add = torch.Tensor.add.op
 
 
 # ---- Internal functions
@@ -266,25 +546,28 @@ def linear_flops_counter_hook(module, input, output):
     input = input[0]
     # pytorch checks dimensions, so here we don't care much
     output_last_dim = output.shape[-1]
+    input_last_dim = input.shape[-1]
+    pre_last_dims_prod = np.prod(input.shape[0:-1], dtype=np.int64)
     bias_flops = output_last_dim if module.bias is not None else 0
-    module.__flops__ += int(np.prod(input.shape) * output_last_dim + bias_flops)
+    module.__flops__ += int((input_last_dim * output_last_dim + bias_flops)
+                            * pre_last_dims_prod)
 
 
 def pool_flops_counter_hook(module, input, output):
     input = input[0]
-    module.__flops__ += int(np.prod(input.shape))
+    module.__flops__ += int(np.prod(input.shape, dtype=np.int64))
 
 
 def bn_flops_counter_hook(module, input, output):
     input = input[0]
 
-    batch_flops = np.prod(input.shape)
-    if module.affine:
+    batch_flops = np.prod(input.shape, dtype=np.int64)
+    if hasattr(module, "affine") and module.affine:
         batch_flops *= 2
     module.__flops__ += int(batch_flops)
 
 
-def conv_flops_counter_hook(conv_module, input, output):
+def conv_flops_counter_hook(conv_module, input, output, extra_per_position_flops=0):
     # Can have multiple inputs, getting the first one
     input = input[0]
 
@@ -297,10 +580,10 @@ def conv_flops_counter_hook(conv_module, input, output):
     groups = conv_module.groups
 
     filters_per_channel = out_channels // groups
-    conv_per_position_flops = int(np.prod(kernel_dims)) * \
-        in_channels * filters_per_channel
+    conv_per_position_flops = int(np.prod(kernel_dims, dtype=np.int64)) * \
+        (in_channels * filters_per_channel + extra_per_position_flops)
 
-    active_elements_count = batch_size * int(np.prod(output_dims))
+    active_elements_count = batch_size * int(np.prod(output_dims, dtype=np.int64))
 
     overall_conv_flops = conv_per_position_flops * active_elements_count
 
@@ -315,24 +598,21 @@ def conv_flops_counter_hook(conv_module, input, output):
     conv_module.__flops__ += int(overall_flops)
 
 
-def batch_counter_hook(module, input, output):
-    batch_size = 1
-    if len(input) > 0:
-        # Can have multiple inputs, getting the first one
-        input = input[0]
-        batch_size = len(input)
-    else:
-        pass
-        _logger.info('Warning! No positional inputs found for a module,'
-                     ' assuming batch size is 1.')
-    module.__batch_counter__ += batch_size
+def deformable_conv_flops_counter_hook(conv_module, input, output):
+    # 20 = 4 x 5 is an approximate cost of billinear interpolation, 2x2 grid is used
+    # 4 is an approximate cost of fractional coordinates computation
+    deformable_conv_extra_complexity = 20 + 4
+    # consider also modulation multiplication
+    if len(input) == 3 and input[2] is not None:
+        deformable_conv_extra_complexity += 1
+    conv_flops_counter_hook(conv_module, input, output, deformable_conv_extra_complexity)
 
 
 def rnn_flops(flops, rnn_module, w_ih, w_hh, input_size):
     # matrix matrix mult ih state and internal state
-    flops += w_ih.shape[0] * w_ih.shape[1]
+    flops += w_ih.shape[0]*w_ih.shape[1]
     # matrix matrix mult hh state and internal state
-    flops += w_hh.shape[0] * w_hh.shape[1]
+    flops += w_hh.shape[0]*w_hh.shape[1]
     if isinstance(rnn_module, (nn.RNN, nn.RNNCell)):
         # add both operations
         flops += rnn_module.hidden_size
@@ -340,12 +620,12 @@ def rnn_flops(flops, rnn_module, w_ih, w_hh, input_size):
         # hadamard of r
         flops += rnn_module.hidden_size
         # adding operations from both states
-        flops += rnn_module.hidden_size * 3
+        flops += rnn_module.hidden_size*3
         # last two hadamard product and add
-        flops += rnn_module.hidden_size * 3
+        flops += rnn_module.hidden_size*3
     elif isinstance(rnn_module, (nn.LSTM, nn.LSTMCell)):
         # adding operations from both states
-        flops += rnn_module.hidden_size * 4
+        flops += rnn_module.hidden_size*4
         # two hadamard product and add for C state
         flops += rnn_module.hidden_size + rnn_module.hidden_size + rnn_module.hidden_size
         # final hadamard
@@ -357,7 +637,7 @@ def rnn_flops_counter_hook(rnn_module, input, output):
     """
     Takes into account batch goes at first position, contrary
     to pytorch common rule (but actually it doesn't matter).
-    IF sigmoid and tanh are made hard, only a comparison FLOPS should be accurate
+    If sigmoid and tanh are hard, only a comparison FLOPS should be accurate
     """
     flops = 0
     # input is a tuple containing a sequence to process and (optionally) hidden state
@@ -405,68 +685,91 @@ def rnn_cell_flops_counter_hook(rnn_cell_module, input, output):
 
 def multihead_attention_counter_hook(multihead_attention_module, input, output):
     flops = 0
+
     q, k, v = input
-    batch_size = q.shape[1]
+
+    batch_first = multihead_attention_module.batch_first \
+        if hasattr(multihead_attention_module, 'batch_first') else False
+    if batch_first:
+        batch_size = q.shape[0]
+        len_idx = 1
+    else:
+        batch_size = q.shape[1]
+        len_idx = 0
+
+    dim_idx = 2
+
+    qdim = q.shape[dim_idx]
+    kdim = k.shape[dim_idx]
+    vdim = v.shape[dim_idx]
+
+    qlen = q.shape[len_idx]
+    klen = k.shape[len_idx]
+    vlen = v.shape[len_idx]
 
     num_heads = multihead_attention_module.num_heads
-    embed_dim = multihead_attention_module.embed_dim
-    kdim = multihead_attention_module.kdim
-    vdim = multihead_attention_module.vdim
-    if kdim is None:
-        kdim = embed_dim
-    if vdim is None:
-        vdim = embed_dim
+    assert qdim == multihead_attention_module.embed_dim
 
-    # initial projections
-    flops = q.shape[0] * q.shape[2] * embed_dim + \
-        k.shape[0] * k.shape[2] * kdim + \
-        v.shape[0] * v.shape[2] * vdim
+    if multihead_attention_module.kdim is None:
+        assert kdim == qdim
+    if multihead_attention_module.vdim is None:
+        assert vdim == qdim
+
+    flops = 0
+
+    # Q scaling
+    flops += qlen * qdim
+
+    # Initial projections
+    flops += (
+        (qlen * qdim * qdim)  # QW
+        + (klen * kdim * kdim)  # KW
+        + (vlen * vdim * vdim)  # VW
+    )
+
     if multihead_attention_module.in_proj_bias is not None:
-        flops += (q.shape[0] + k.shape[0] + v.shape[0]) * embed_dim
+        flops += (qlen + klen + vlen) * qdim
 
     # attention heads: scale, matmul, softmax, matmul
-    head_dim = embed_dim // num_heads
-    head_flops = q.shape[0] * head_dim + \
-        head_dim * q.shape[0] * k.shape[0] + \
-        q.shape[0] * k.shape[0] + \
-        q.shape[0] * k.shape[0] * head_dim
+    qk_head_dim = qdim // num_heads
+    v_head_dim = vdim // num_heads
+
+    head_flops = (
+        (qlen * klen * qk_head_dim)  # QK^T
+        + (qlen * klen)  # softmax
+        + (qlen * klen * v_head_dim)  # AV
+    )
 
     flops += num_heads * head_flops
 
     # final projection, bias is always enabled
-    flops += q.shape[0] * embed_dim * (embed_dim + 1)
+    flops += qlen * vdim * (vdim + 1)
 
     flops *= batch_size
     multihead_attention_module.__flops__ += int(flops)
 
 
-def add_batch_counter_variables_or_reset(module):
+def timm_attention_counter_hook(attention_module, input, output):
+    flops = 0
+    B, N, C = input[0].shape  # [Batch_size, Seq_len, Dimension]
 
-    module.__batch_counter__ = 0
+    # QKV projection is already covered in MODULES_MAPPING
 
+    # Q scaling
+    flops += N * attention_module.head_dim * attention_module.num_heads
 
-def add_batch_counter_hook_function(module):
-    if hasattr(module, '__batch_counter_handle__'):
-        return
+    # head flops
+    head_flops = (
+        (N * N * attention_module.head_dim)  # QK^T
+        + (N * N)  # softmax
+        + (N * N * attention_module.head_dim)  # AV
+    )
+    flops += head_flops * attention_module.num_heads
 
-    handle = module.register_forward_hook(batch_counter_hook)
-    module.__batch_counter_handle__ = handle
+    # Final projection is already covered in MODULES_MAPPING
 
-
-def remove_batch_counter_hook_function(module):
-    if hasattr(module, '__batch_counter_handle__'):
-        module.__batch_counter_handle__.remove()
-        del module.__batch_counter_handle__
-
-
-def add_flops_counter_variable_or_reset(module):
-    if is_supported_instance(module):
-        if hasattr(module, '__flops__') or hasattr(module, '__params__'):
-            _logger.info('Warning: variables __flops__ or __params__ are already '
-                         'defined for the module' + type(module).__name__ +
-                         ' ptflops can affect your code!')
-        module.__flops__ = 0
-        module.__params__ = get_model_parameters_number(module)
+    flops *= B
+    attention_module.__flops__ += int(flops)
 
 
 CUSTOM_MODULES_MAPPING = {}
@@ -499,6 +802,12 @@ MODULES_MAPPING = {
     nn.BatchNorm1d: bn_flops_counter_hook,
     nn.BatchNorm2d: bn_flops_counter_hook,
     nn.BatchNorm3d: bn_flops_counter_hook,
+
+    nn.InstanceNorm1d: bn_flops_counter_hook,
+    nn.InstanceNorm2d: bn_flops_counter_hook,
+    nn.InstanceNorm3d: bn_flops_counter_hook,
+    nn.GroupNorm: bn_flops_counter_hook,
+    nn.LayerNorm: bn_flops_counter_hook,
     # FC
     nn.Linear: linear_flops_counter_hook,
     # Upscale
@@ -517,15 +826,146 @@ MODULES_MAPPING = {
     nn.MultiheadAttention: multihead_attention_counter_hook
 }
 
+if hasattr(nn, 'GELU'):
+    MODULES_MAPPING[nn.GELU] = relu_flops_counter_hook
 
-def is_supported_instance(module):
-    if type(module) in MODULES_MAPPING or type(module) in CUSTOM_MODULES_MAPPING:
-        return True
-    return False
+try:
+    import torchvision.ops as tops
+    MODULES_MAPPING[tops.DeformConv2d] = deformable_conv_flops_counter_hook
+except ImportError:
+    pass
+
+try:
+    from timm.models.vision_transformer import Attention as timm_Attention
+    MODULES_MAPPING[timm_Attention] = timm_attention_counter_hook
+except ImportError:
+    pass
 
 
-def remove_flops_counter_hook_function(module):
-    if is_supported_instance(module):
-        if hasattr(module, '__flops_handle__'):
-            module.__flops_handle__.remove()
-            del module.__flops_handle__
+def _linear_functional_flops_hook(input, weight, bias=None):
+    out_features = weight.shape[0]
+    macs = input.numel() * out_features
+    if bias is not None:
+        macs += out_features
+    return macs
+
+
+def _numel_functional_flops_hook(input, *args, **kwargs):
+    return input.numel()
+
+
+def _interpolate_functional_flops_hook(*args, **kwargs):
+    input = kwargs.get('input', None)
+    if input is None and len(args) > 0:
+        input = args[0]
+
+    size = kwargs.get('size', None)
+    if size is None and len(args) > 1:
+        size = args[1]
+
+    if size is not None:
+        if isinstance(size, tuple) or isinstance(size, list):
+            return int(np.prod(size, dtype=np.int64))
+        else:
+            return int(size)
+
+    scale_factor = kwargs.get('scale_factor', None)
+    if scale_factor is None and len(args) > 2:
+        scale_factor = args[2]
+    assert scale_factor is not None, "either size or scale_factor"
+    "should be passes to interpolate"
+
+    flops = input.numel()
+    if isinstance(scale_factor, tuple) and len(scale_factor) == len(input):
+        flops *= int(np.prod(scale_factor, dtype=np.int64))
+    else:
+        flops *= scale_factor**len(input)
+
+    return flops
+
+
+def _matmul_tensor_flops_hook(input, other, *args, **kwargs):
+    flops = np.prod(input.shape, dtype=np.int64) * other.shape[-1]
+    return flops
+
+
+def _addmm_tensor_flops_hook(input, mat1, mat2, *, beta=1, alpha=1, out=None):
+    flops = np.prod(mat1.shape, dtype=np.int64) * mat2.shape[-1]
+    if beta != 0:
+        flops += np.prod(input.shape, dtype=np.int64)
+    return flops
+
+
+def _elementwise_tensor_flops_hook(input, other, *args, **kwargs):
+    if not torch.is_tensor(input):
+        if torch.is_tensor(other):
+            return np.prod(other.shape, dtype=np.int64)
+        else:
+            return 1
+    elif not torch.is_tensor(other):
+        return np.prod(input.shape, dtype=np.int64)
+    else:
+        dim_input = len(input.shape)
+        dim_other = len(other.shape)
+        max_dim = max(dim_input, dim_other)
+
+        final_shape = []
+        for i in range(max_dim):
+            in_i = input.shape[i] if i < dim_input else 1
+            ot_i = other.shape[i] if i < dim_other else 1
+            if in_i > ot_i:
+                final_shape.append(in_i)
+            else:
+                final_shape.append(ot_i)
+        flops = np.prod(final_shape, dtype=np.int64)
+        return flops
+
+
+FUNCTIONAL_MAPPING = {
+    F.linear: _linear_functional_flops_hook,
+    F.relu: _numel_functional_flops_hook,
+    F.prelu: _numel_functional_flops_hook,
+    F.elu: _numel_functional_flops_hook,
+    F.relu6: _numel_functional_flops_hook,
+    F.gelu: _numel_functional_flops_hook,
+
+    F.avg_pool1d: _numel_functional_flops_hook,
+    F.avg_pool2d: _numel_functional_flops_hook,
+    F.avg_pool3d: _numel_functional_flops_hook,
+    F.max_pool1d: _numel_functional_flops_hook,
+    F.max_pool2d: _numel_functional_flops_hook,
+    F.max_pool3d: _numel_functional_flops_hook,
+    F.adaptive_avg_pool1d: _numel_functional_flops_hook,
+    F.adaptive_avg_pool2d: _numel_functional_flops_hook,
+    F.adaptive_avg_pool3d: _numel_functional_flops_hook,
+    F.adaptive_max_pool1d: _numel_functional_flops_hook,
+    F.adaptive_max_pool2d: _numel_functional_flops_hook,
+    F.adaptive_max_pool3d: _numel_functional_flops_hook,
+
+    F.softmax: _numel_functional_flops_hook,
+
+    F.upsample: _interpolate_functional_flops_hook,
+    F.interpolate: _interpolate_functional_flops_hook,
+}
+
+if hasattr(F, "silu"):
+    FUNCTIONAL_MAPPING[F.silu] = _numel_functional_flops_hook
+
+
+TENSOR_OPS_MAPPING = {
+    torch.matmul: _matmul_tensor_flops_hook,
+    torch.Tensor.matmul: _matmul_tensor_flops_hook,
+    torch.mm: _matmul_tensor_flops_hook,
+    torch.Tensor.mm: _matmul_tensor_flops_hook,
+    torch.bmm: _matmul_tensor_flops_hook,
+    torch.Tensor.bmm: _matmul_tensor_flops_hook,
+
+    torch.addmm: _addmm_tensor_flops_hook,
+    torch.baddbmm: _addmm_tensor_flops_hook,
+    torch.Tensor.addmm: _addmm_tensor_flops_hook,
+
+    torch.mul: _elementwise_tensor_flops_hook,
+    torch.Tensor.mul: _elementwise_tensor_flops_hook,
+    torch.add: _elementwise_tensor_flops_hook,
+    torch.Tensor.add: _elementwise_tensor_flops_hook,
+}


### PR DESCRIPTION
## Add --run-mode

Specify the run mode. Syntax: `--run-mode train,val,test`

## Small fix on the floating-point precision issue in --fetch-step

The floating-point error may accumulate and cause e.g. `self.ipos` = 0.99999999 such that the stop point is not triggered

## Small fix on the self-mapping removal code
https://github.com/hqucms/weaver-core/pull/18/commits/eaace4d5dcf0cc7058607c4f771384de12dc592a

## Update flops_counter.

The `flops_counter.py` is updated to the latest version in https://github.com/sovrasov/flops-counter.pytorch
The code is adapted to weaver-core according to its original form

Several changes are observed:
 - FLOPs produced from torch.nn functionals (such as F.relu) and torch operations (such as `torch.bmm`, `torch.mul`) is now considered.
 - more modules are supported to compute FLOPs, e.g. `nn.LayerNorm`, `nn.GELU`.
 - a bug in computing FLOPs in `nn.Linear` on the bias term is fixed in the latest version of the code.

Comparison of the old/new impl. when performed on the latest ParT model.

```diff
1,2c1,2
< [2024-08-06 00:29:52,079] INFO: ParticleTransformerWrapper(
<   |2.123 M, 99.021% Params, 247.353 MMac, 100.000% MACs|
---
> [2024-08-06 00:29:33,592] INFO: ParticleTransformerWrapper(
>   |2.142 M, 99.931% Params, 251.542 MMac, 92.948% MACs|
4c4
<     |2.123 M, 99.021% Params, 247.353 MMac, 100.000% MACs|
---
>     |2.142 M, 99.931% Params, 251.542 MMac, 92.948% MACs|
7c7
<       |0.134 M, 6.254% Params, 17.061 MMac, 6.897% MACs|
---
>       |0.135 M, 6.315% Params, 17.341 MMac, 6.408% MACs|
10,19c10,19
<         |0.134 M, 6.252% Params, 17.057 MMac, 6.896% MACs|
<         (0): LayerNorm((17,), eps=1e-05, elementwise_affine=True, |0.0 M, 0.000% Params, 0.0 Mac, 0.000% MACs|)
<         (1): Linear(in_features=17, out_features=128, bias=True, |0.002 M, 0.107% Params, 278.656 KMac, 0.113% MACs|)
<         (2): GELU(approximate='none', |0.0 M, 0.000% Params, 0.0 Mac, 0.000% MACs|)
<         (3): LayerNorm((128,), eps=1e-05, elementwise_affine=True, |0.0 M, 0.000% Params, 0.0 Mac, 0.000% MACs|)
<         (4): Linear(in_features=128, out_features=512, bias=True, |0.066 M, 3.081% Params, 8.389 MMac, 3.392% MACs|)
<         (5): GELU(approximate='none', |0.0 M, 0.000% Params, 0.0 Mac, 0.000% MACs|)
<         (6): LayerNorm((512,), eps=1e-05, elementwise_affine=True, |0.0 M, 0.000% Params, 0.0 Mac, 0.000% MACs|)
<         (7): Linear(in_features=512, out_features=128, bias=True, |0.066 M, 3.063% Params, 8.389 MMac, 3.391% MACs|)
<         (8): GELU(approximate='none', |0.0 M, 0.000% Params, 0.0 Mac, 0.000% MACs|)
---
>         |0.135 M, 6.314% Params, 17.336 MMac, 6.406% MACs|
>         (0): LayerNorm((17,), eps=1e-05, elementwise_affine=True, |0.0 M, 0.002% Params, 2.176 KMac, 0.001% MACs|)
>         (1): Linear(in_features=17, out_features=128, bias=True, |0.002 M, 0.107% Params, 294.912 KMac, 0.109% MACs|)
>         (2): GELU(approximate='none', |0.0 M, 0.000% Params, 16.384 KMac, 0.006% MACs|)
>         (3): LayerNorm((128,), eps=1e-05, elementwise_affine=True, |0.0 M, 0.012% Params, 16.384 KMac, 0.006% MACs|)
>         (4): Linear(in_features=128, out_features=512, bias=True, |0.066 M, 3.081% Params, 8.454 MMac, 3.124% MACs|)
>         (5): GELU(approximate='none', |0.0 M, 0.000% Params, 65.536 KMac, 0.024% MACs|)
>         (6): LayerNorm((512,), eps=1e-05, elementwise_affine=True, |0.001 M, 0.048% Params, 65.536 KMac, 0.024% MACs|)
>         (7): Linear(in_features=512, out_features=128, bias=True, |0.066 M, 3.063% Params, 8.405 MMac, 3.106% MACs|)
>         (8): GELU(approximate='none', |0.0 M, 0.000% Params, 16.384 KMac, 0.006% MACs|)
23c23
<       |0.01 M, 0.446% Params, 78.993 MMac, 31.935% MACs|
---
>       |0.01 M, 0.446% Params, 80.645 MMac, 29.799% MACs|
25,38c25,38
<         |0.01 M, 0.446% Params, 78.993 MMac, 31.935% MACs|
<         (0): BatchNorm1d(4, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True, |0.0 M, 0.000% Params, 66.048 KMac, 0.027% MACs|)
<         (1): Conv1d(4, 64, kernel_size=(1,), stride=(1,), |0.0 M, 0.015% Params, 2.642 MMac, 1.068% MACs|)
<         (2): BatchNorm1d(64, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True, |0.0 M, 0.006% Params, 1.057 MMac, 0.427% MACs|)
<         (3): GELU(approximate='none', |0.0 M, 0.000% Params, 0.0 Mac, 0.000% MACs|)
<         (4): Conv1d(64, 64, kernel_size=(1,), stride=(1,), |0.004 M, 0.194% Params, 34.345 MMac, 13.885% MACs|)
<         (5): BatchNorm1d(64, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True, |0.0 M, 0.006% Params, 1.057 MMac, 0.427% MACs|)
<         (6): GELU(approximate='none', |0.0 M, 0.000% Params, 0.0 Mac, 0.000% MACs|)
<         (7): Conv1d(64, 64, kernel_size=(1,), stride=(1,), |0.004 M, 0.194% Params, 34.345 MMac, 13.885% MACs|)
<         (8): BatchNorm1d(64, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True, |0.0 M, 0.006% Params, 1.057 MMac, 0.427% MACs|)
<         (9): GELU(approximate='none', |0.0 M, 0.000% Params, 0.0 Mac, 0.000% MACs|)
<         (10): Conv1d(64, 8, kernel_size=(1,), stride=(1,), |0.001 M, 0.024% Params, 4.293 MMac, 1.736% MACs|)
<         (11): BatchNorm1d(8, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True, |0.0 M, 0.001% Params, 132.096 KMac, 0.053% MACs|)
<         (12): GELU(approximate='none', |0.0 M, 0.000% Params, 0.0 Mac, 0.000% MACs|)
---
>         |0.01 M, 0.446% Params, 80.645 MMac, 29.799% MACs|
>         (0): BatchNorm1d(4, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True, |0.0 M, 0.000% Params, 66.048 KMac, 0.024% MACs|)
>         (1): Conv1d(4, 64, kernel_size=(1,), stride=(1,), |0.0 M, 0.015% Params, 2.642 MMac, 0.976% MACs|)
>         (2): BatchNorm1d(64, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True, |0.0 M, 0.006% Params, 1.057 MMac, 0.390% MACs|)
>         (3): GELU(approximate='none', |0.0 M, 0.000% Params, 528.384 KMac, 0.195% MACs|)
>         (4): Conv1d(64, 64, kernel_size=(1,), stride=(1,), |0.004 M, 0.194% Params, 34.345 MMac, 12.691% MACs|)
>         (5): BatchNorm1d(64, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True, |0.0 M, 0.006% Params, 1.057 MMac, 0.390% MACs|)
>         (6): GELU(approximate='none', |0.0 M, 0.000% Params, 528.384 KMac, 0.195% MACs|)
>         (7): Conv1d(64, 64, kernel_size=(1,), stride=(1,), |0.004 M, 0.194% Params, 34.345 MMac, 12.691% MACs|)
>         (8): BatchNorm1d(64, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True, |0.0 M, 0.006% Params, 1.057 MMac, 0.390% MACs|)
>         (9): GELU(approximate='none', |0.0 M, 0.000% Params, 528.384 KMac, 0.195% MACs|)
>         (10): Conv1d(64, 8, kernel_size=(1,), stride=(1,), |0.001 M, 0.024% Params, 4.293 MMac, 1.586% MACs|)
>         (11): BatchNorm1d(8, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True, |0.0 M, 0.001% Params, 132.096 KMac, 0.049% MACs|)
>         (12): GELU(approximate='none', |0.0 M, 0.000% Params, 66.048 KMac, 0.024% MACs|)
43,44c43,44
<         |0.198 M, 9.226% Params, 18.875 MMac, 7.631% MACs|
<         (pre_attn_norm): LayerNorm((128,), eps=1e-05, elementwise_affine=True, |0.0 M, 0.000% Params, 0.0 Mac, 0.000% MACs|)
---
>         |0.2 M, 9.310% Params, 19.153 MMac, 7.077% MACs|
>         (pre_attn_norm): LayerNorm((128,), eps=1e-05, elementwise_affine=True, |0.0 M, 0.012% Params, 16.384 KMac, 0.006% MACs|)
46c46
<           |0.066 M, 3.081% Params, 2.097 MMac, 0.848% MACs|
---
>           |0.066 M, 3.081% Params, 2.114 MMac, 0.781% MACs|
48c48
<           (out_proj): Linear(in_features=128, out_features=128, bias=True, |0.017 M, 0.770% Params, 2.097 MMac, 0.848% MACs|)
---
>           (out_proj): Linear(in_features=128, out_features=128, bias=True, |0.017 M, 0.770% Params, 2.114 MMac, 0.781% MACs|)
50c50
<         (post_attn_norm): LayerNorm((128,), eps=1e-05, elementwise_affine=True, |0.0 M, 0.000% Params, 0.0 Mac, 0.000% MACs|)
---
>         (post_attn_norm): LayerNorm((128,), eps=1e-05, elementwise_affine=True, |0.0 M, 0.012% Params, 16.384 KMac, 0.006% MACs|)
54,56c54,56
<         (pre_fc_norm): LayerNorm((128,), eps=1e-05, elementwise_affine=True, |0.0 M, 0.000% Params, 0.0 Mac, 0.000% MACs|)
<         (fc1): Linear(in_features=128, out_features=512, bias=True, |0.066 M, 3.081% Params, 8.389 MMac, 3.392% MACs|)
<         (act): GELU(approximate='none', |0.0 M, 0.000% Params, 0.0 Mac, 0.000% MACs|)
---
>         (pre_fc_norm): LayerNorm((128,), eps=1e-05, elementwise_affine=True, |0.0 M, 0.012% Params, 16.384 KMac, 0.006% MACs|)
>         (fc1): Linear(in_features=128, out_features=512, bias=True, |0.066 M, 3.081% Params, 8.454 MMac, 3.124% MACs|)
>         (act): GELU(approximate='none', |0.0 M, 0.000% Params, 65.536 KMac, 0.024% MACs|)
58,59c58,59
<         (post_fc_norm): LayerNorm((512,), eps=1e-05, elementwise_affine=True, |0.0 M, 0.000% Params, 0.0 Mac, 0.000% MACs|)
<         (fc2): Linear(in_features=512, out_features=128, bias=True, |0.066 M, 3.063% Params, 8.389 MMac, 3.391% MACs|)
---
>         (post_fc_norm): LayerNorm((512,), eps=1e-05, elementwise_affine=True, |0.001 M, 0.048% Params, 65.536 KMac, 0.024% MACs|)
>         (fc2): Linear(in_features=512, out_features=128, bias=True, |0.066 M, 3.063% Params, 8.405 MMac, 3.106% MACs|)
66,67c66,67
<         |0.198 M, 9.226% Params, 148.224 KMac, 0.060% MACs|
<         (pre_attn_norm): LayerNorm((128,), eps=1e-05, elementwise_affine=True, |0.0 M, 0.000% Params, 0.0 Mac, 0.000% MACs|)
---
>         |0.2 M, 9.310% Params, 166.016 KMac, 0.061% MACs|
>         (pre_attn_norm): LayerNorm((128,), eps=1e-05, elementwise_affine=True, |0.0 M, 0.012% Params, 16.512 KMac, 0.006% MACs|)
69c69
<           |0.066 M, 3.081% Params, 16.512 KMac, 0.007% MACs|
---
>           |0.066 M, 3.081% Params, 16.512 KMac, 0.006% MACs|
71c71
<           (out_proj): Linear(in_features=128, out_features=128, bias=True, |0.017 M, 0.770% Params, 16.512 KMac, 0.007% MACs|)
---
>           (out_proj): Linear(in_features=128, out_features=128, bias=True, |0.017 M, 0.770% Params, 16.512 KMac, 0.006% MACs|)
73c73
<         (post_attn_norm): LayerNorm((128,), eps=1e-05, elementwise_affine=True, |0.0 M, 0.000% Params, 0.0 Mac, 0.000% MACs|)
---
>         (post_attn_norm): LayerNorm((128,), eps=1e-05, elementwise_affine=True, |0.0 M, 0.012% Params, 128.0 Mac, 0.000% MACs|)
77,79c77,79
<         (pre_fc_norm): LayerNorm((128,), eps=1e-05, elementwise_affine=True, |0.0 M, 0.000% Params, 0.0 Mac, 0.000% MACs|)
<         (fc1): Linear(in_features=128, out_features=512, bias=True, |0.066 M, 3.081% Params, 66.048 KMac, 0.027% MACs|)
<         (act): GELU(approximate='none', |0.0 M, 0.000% Params, 0.0 Mac, 0.000% MACs|)
---
>         (pre_fc_norm): LayerNorm((128,), eps=1e-05, elementwise_affine=True, |0.0 M, 0.012% Params, 128.0 Mac, 0.000% MACs|)
>         (fc1): Linear(in_features=128, out_features=512, bias=True, |0.066 M, 3.081% Params, 66.048 KMac, 0.024% MACs|)
>         (act): GELU(approximate='none', |0.0 M, 0.000% Params, 512.0 Mac, 0.000% MACs|)
81,82c81,82
<         (post_fc_norm): LayerNorm((512,), eps=1e-05, elementwise_affine=True, |0.0 M, 0.000% Params, 0.0 Mac, 0.000% MACs|)
<         (fc2): Linear(in_features=512, out_features=128, bias=True, |0.066 M, 3.063% Params, 65.664 KMac, 0.027% MACs|)
---
>         (post_fc_norm): LayerNorm((512,), eps=1e-05, elementwise_affine=True, |0.001 M, 0.048% Params, 512.0 Mac, 0.000% MACs|)
>         (fc2): Linear(in_features=512, out_features=128, bias=True, |0.066 M, 3.063% Params, 65.664 KMac, 0.024% MACs|)
87c87
<     (norm): LayerNorm((128,), eps=1e-05, elementwise_affine=True, |0.0 M, 0.000% Params, 0.0 Mac, 0.000% MACs|)
---
>     (norm): LayerNorm((128,), eps=1e-05, elementwise_affine=True, |0.0 M, 0.012% Params, 128.0 Mac, 0.000% MACs|)
89,90c89,90
<       |0.001 M, 0.060% Params, 1.29 KMac, 0.001% MACs|
<       (0): Linear(in_features=128, out_features=10, bias=True, |0.001 M, 0.060% Params, 1.29 KMac, 0.001% MACs|)
---
>       |0.001 M, 0.060% Params, 1.29 KMac, 0.000% MACs|
>       (0): Linear(in_features=128, out_features=10, bias=True, |0.001 M, 0.060% Params, 1.29 KMac, 0.000% MACs|)
94,95c94,95
< [2024-08-06 00:29:52,081] INFO: Computational complexity:       247.35 MMac
< [2024-08-06 00:29:52,082] INFO: Number of parameters:           2.14 M
---
> [2024-08-06 00:29:33,629] INFO: Computational complexity:       270.63 MMac
> [2024-08-06 00:29:33,629] INFO: Number of parameters:           2.14 M
```