### PR TITLE
Improve --data-split-num (minor tweak of #19)

### DIFF
--- a/weaver/utils/data/fileio.py
+++ b/weaver/utils/data/fileio.py
@@ -76,14 +76,15 @@ def _read_parquet(filepath, branches, load_range=None):
     return outputs
 
 
-def _read_files(filelist, branches, load_range=None, show_progressbar=False, file_magic=None, **kwargs):
+def _read_files(filelist, branches, load_ranges=None, show_progressbar=False, file_magic=None, **kwargs):
     import os
     branches = list(branches)
     table = []
     if show_progressbar:
         filelist = tqdm.tqdm(filelist)
-    for filepath in filelist:
+    for i_file, filepath in enumerate(filelist):
         ext = os.path.splitext(filepath)[1]
+        load_range = None if load_ranges is None else load_ranges[i_file]
         if ext not in ('.h5', '.root', '.awkd', '.parquet'):
             raise RuntimeError('File %s of type `%s` is not supported!' % (filepath, ext))
         try:


### PR DESCRIPTION
Minor tweak of https://github.com/hqucms/weaver-core/pull/19.

> When input dataset is in Parquet format, the entire file must be first read into the memory and then select events from start_entry:stop_entry. This makes `--fetch-step 0.01` still requires loading all datasets into the memory.
> 
> A simple solution to efficiently read Parquet dataset, without affecting the exiting function is to use `--fetch-step 1 --data-split-num 100` (recently added to weaver) instead of  `--fetch-step 0.01`. Therefore, this PR improves `--data-split-num` by handle the split in separate input groups, and allowing it to split more evenly.
> 
> For example, input datasets are separated into groups `process_1: filelist_1, process_2:filelist_2, …`. Now,
> - `--data-split-num` split data separately in each group so that the mixing is even among the groups.
> - In each group, `--data-split-num` can handle the case if N(file) is not divisible by the split number. Say, for `N=5` and `split_num=3`, in the case of `load_range=(0, 0.1)`, we have
> ```
> iter1: load file 0, 1; load_ranges=[(0, 0.1), (0, 0.0667)]
> iter2: load file 1, 2, 3; load_ranges=[(0.0667, 0.1), (0, 0.1), (0, 0.0333)]
> iter3: load file 3, 4; load_ranges=[(0.0333, 0.1), (0, 0.1)]
> ```
> 
> The initial impl. of `--data-split-num` (achieved inside the function `_load_next`) has been reverted.
> 