### PR TITLE
Fix ONNX export for ParticleTransformer

### DIFF
--- a/test/networks/example_ParT.py
+++ b/test/networks/example_ParT.py
@@ -1,0 +1,46 @@
+"""Example ParticleTransformer network config.
+
+It follows the standard weaver network-config interface (``get_model`` / ``get_loss``).
+
+This file is intentionally NOT named ``test_*`` so pytest does not collect it.
+"""
+
+import torch
+
+from weaver.nn.model.ParticleTransformer import ParticleTransformer
+
+
+class ParticleTransformerWrapper(torch.nn.Module):
+    def __init__(self, **kwargs):
+        super().__init__()
+        self.mod = ParticleTransformer(**kwargs)
+
+    @torch.jit.ignore
+    def no_weight_decay(self):
+        return {"mod.cls_token"}
+
+    def forward(self, points, features, lorentz_vectors, mask):
+        return self.mod(features, v=lorentz_vectors, mask=mask)
+
+
+def get_model(data_config, **kwargs):
+    cfg = dict(
+        input_dim=len(data_config.input_dicts["pf_features"]),
+        num_classes=len(data_config.label_value),
+    )
+    cfg.update(**kwargs)
+    model = ParticleTransformerWrapper(**cfg)
+    model_info = {
+        "input_names": list(data_config.input_names),
+        "input_shapes": {k: ((1,) + s[1:]) for k, s in data_config.input_shapes.items()},
+        "output_names": ["softmax"],
+        "dynamic_axes": {
+            **{k: {0: "N", 2: "n_" + k.split("_")[0]} for k in data_config.input_names},
+            **{"softmax": {0: "N"}},
+        },
+    }
+    return model, model_info
+
+
+def get_loss(data_config, **kwargs):
+    return torch.nn.CrossEntropyLoss()

--- a/test/test_onnx_export.py
+++ b/test/test_onnx_export.py
@@ -1,0 +1,138 @@
+"""Unit tests for exporting ParticleTransformer to ONNX.
+
+These drive the real export entry point, ``weaver.train.onnx``, so the whole
+production path (``model_setup`` -> checkpoint load -> ``torch.onnx.export`` ->
+``preprocess.json``) is covered. They guard in particular:
+
+* ``version >= 3`` uses RMS normalization. The native ``torch.nn.RMSNorm``
+  cannot be exported by the TorchScript ONNX exporter (no ``aten::rms_norm``
+  symbolic), so the model swaps in an ONNX-friendly ``RMSNorm`` when built with
+  ``for_inference=True`` while keeping the native (fused) one for training.
+* The exported graph must reproduce the PyTorch model's output numerically.
+"""
+
+import argparse
+import os
+import tempfile
+import unittest
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+try:
+    import onnxruntime as ort
+
+    _HAS_ORT = True
+except ImportError:
+    _HAS_ORT = False
+
+from weaver import train as weaver_train
+from weaver.utils.dataset import DataConfig
+from weaver.utils.import_tools import import_module
+from weaver.nn.model.ParticleTransformer import RMSNorm
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_DATA_CONFIG = os.path.join(_HERE, "data", "JetClass_full.yaml")
+_NETWORK_CONFIG = os.path.join(_HERE, "networks", "example_ParT.py")
+_NATIVE_RMSNORM = getattr(nn, "RMSNorm", None)
+
+
+def _make_args(workdir, version):
+    """Minimal args namespace accepted by ``weaver.train.onnx`` / ``model_setup``."""
+    return argparse.Namespace(
+        data_config=_DATA_CONFIG,
+        network_config=_NETWORK_CONFIG,
+        network_option=[["version", str(version)]],
+        model_prefix=os.path.join(workdir, "net.pt"),
+        export_onnx=os.path.join(workdir, "model.onnx"),
+        onnx_opset=15,
+        use_amp=False,
+        compile=False,
+        load_model_weights=None,
+        exclude_model_weights=None,
+        freeze_model_weights=None,
+        regression_mode=False,
+    )
+
+
+def _physical_inputs(data_config, batch=1, seed=1):
+    """Realistic inputs: non-zero (wrap-like) 4-vectors to avoid atan2(0, 0) NaNs."""
+    g = torch.Generator().manual_seed(seed)
+    shapes = {k: (batch,) + s[1:] for k, s in data_config.input_shapes.items()}
+    inp = {k: torch.randn(*shp, generator=g) for k, shp in shapes.items()}
+    seq_len = shapes["pf_mask"][2]
+    mask = torch.zeros(batch, 1, seq_len)
+    for i in range(batch):
+        mask[i, 0, : min(seq_len, 4 + 3 * i)] = 1
+    inp["pf_mask"] = mask
+    px, py, pz = (torch.randn(batch, 1, seq_len, generator=g) + 0.5 for _ in range(3))
+    m = torch.rand(batch, 1, seq_len, generator=g) * 0.3 + 0.1
+    inp["pf_vectors"] = torch.cat([px, py, pz, torch.sqrt(px**2 + py**2 + pz**2 + m**2)], dim=1)
+    return inp
+
+
+@unittest.skipUnless(_HAS_ORT, "onnxruntime is required for ONNX export tests")
+class OnnxExportTest(unittest.TestCase):
+    def _check_version(self, version):
+        data_config = DataConfig.load(_DATA_CONFIG, load_observers=False, load_reweight_info=False)
+        net = import_module(_NETWORK_CONFIG, name="_onnx_test_net")
+
+        with tempfile.TemporaryDirectory() as workdir:
+            args = _make_args(workdir, version)
+
+            # build a training-mode model (uses native nn.RMSNorm for v3) and
+            # save it as the checkpoint that `train.onnx` will load and export
+            train_model, _ = net.get_model(data_config, version=version)
+            train_model.eval()
+            torch.save(train_model.state_dict(), args.model_prefix)
+
+            # === the export path under test ===
+            weaver_train.onnx(args)
+
+            self.assertTrue(os.path.isfile(args.export_onnx))
+            self.assertTrue(os.path.isfile(os.path.join(workdir, "preprocess.json")))
+
+            # reference output from the (native-RMSNorm) PyTorch model
+            inp = _physical_inputs(data_config, batch=1)
+            with torch.no_grad():
+                logits = train_model(*[inp[k] for k in data_config.input_names])
+                ref = torch.softmax(logits, dim=1).numpy()
+
+            sess = ort.InferenceSession(args.export_onnx, providers=["CPUExecutionProvider"])
+            feed = {i.name: inp[i.name].numpy().astype(np.float32) for i in sess.get_inputs()}
+            out = sess.run(None, feed)[0]
+
+        self.assertFalse(np.isnan(out).any(), msg=f"v{version}: ONNX output contains NaNs")
+        np.testing.assert_allclose(
+            out, ref, rtol=1e-3, atol=1e-4, err_msg=f"v{version}: ONNX output differs from PyTorch"
+        )
+
+    def test_export_v1(self):
+        self._check_version(1)
+
+    def test_export_v2(self):
+        self._check_version(2)
+
+    def test_export_v3(self):
+        self._check_version(3)
+
+    @unittest.skipUnless(_NATIVE_RMSNORM is not None, "torch.nn.RMSNorm is unavailable")
+    def test_v3_rmsnorm_implementation_depends_on_for_inference(self):
+        data_config = DataConfig.load(_DATA_CONFIG, load_observers=False, load_reweight_info=False)
+        net = import_module(_NETWORK_CONFIG, name="_onnx_test_net")
+
+        # training keeps the native (fused) RMSNorm; export swaps in the
+        # ONNX-exportable implementation
+        train_mods = list(net.get_model(data_config, version=3)[0].modules())
+        export_mods = list(net.get_model(data_config, version=3, for_inference=True)[0].modules())
+
+        self.assertTrue(any(isinstance(m, _NATIVE_RMSNORM) for m in train_mods))
+        self.assertFalse(any(type(m) is RMSNorm for m in train_mods))
+
+        self.assertTrue(any(type(m) is RMSNorm for m in export_mods))
+        self.assertFalse(any(isinstance(m, _NATIVE_RMSNORM) for m in export_mods))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/weaver/nn/model/ParticleTransformer.py
+++ b/weaver/nn/model/ParticleTransformer.py
@@ -6,6 +6,7 @@ Paper: "Particle Transformer for Jet Tagging" - https://arxiv.org/abs/2202.03772
 import math
 
 import copy
+import numbers
 from functools import partial
 from typing import Optional, Tuple, Any, Callable
 
@@ -304,6 +305,49 @@ class SequenceTrimmer(nn.Module):
                         v = v[0]
 
         return x, v, mask, uu
+
+
+class RMSNorm(nn.Module):
+    """Root-mean-square layer normalization, exportable to ONNX.
+
+    This is an ONNX-export-only stand-in for ``torch.nn.RMSNorm``. The native
+    ``nn.RMSNorm`` lowers to ``aten::rms_norm``, for which the TorchScript-based
+    ONNX exporter has no symbolic (it fails for every opset), so models using it
+    (ParticleTransformer ``version >= 3``) cannot be exported. This manual
+    implementation decomposes into primitive ops that export cleanly.
+
+    It mirrors ``nn.RMSNorm`` numerically (same ``eps`` default of the input
+    dtype's epsilon) and is state-dict compatible (single ``weight`` parameter),
+    so a model trained with ``nn.RMSNorm`` can be loaded into one built with this
+    class for export. ``nn.RMSNorm`` is kept for training (fused kernel), see
+    ``ParticleTransformer``/``Block`` which select the implementation based on
+    ``for_inference``.
+    """
+
+    def __init__(self, normalized_shape, eps=None, elementwise_affine=True, device=None, dtype=None):
+        super().__init__()
+        if isinstance(normalized_shape, numbers.Integral):
+            normalized_shape = (int(normalized_shape),)
+        self.normalized_shape = tuple(normalized_shape)
+        self.eps = eps
+        self.elementwise_affine = elementwise_affine
+        # dims over which to compute the RMS (the trailing `normalized_shape` dims)
+        self._dims = tuple(range(-len(self.normalized_shape), 0))
+        if self.elementwise_affine:
+            self.weight = nn.Parameter(torch.ones(self.normalized_shape, device=device, dtype=dtype))
+        else:
+            self.register_parameter("weight", None)
+
+    def forward(self, x):
+        eps = self.eps if self.eps is not None else torch.finfo(x.dtype).eps
+        variance = x.pow(2).mean(dim=self._dims, keepdim=True)
+        x_normed = x * torch.rsqrt(variance + eps)
+        if self.weight is not None:
+            x_normed = x_normed * self.weight
+        return x_normed
+
+    def extra_repr(self):
+        return f"{self.normalized_shape}, eps={self.eps}, elementwise_affine={self.elementwise_affine}"
 
 
 class SwiGLUFFN(nn.Module):
@@ -778,6 +822,7 @@ class Block(nn.Module):
         scale_fc=True,
         scale_heads=True,
         scale_resids=True,
+        for_inference=False,
     ):
         super().__init__()
 
@@ -786,7 +831,9 @@ class Block(nn.Module):
         self.head_dim = embed_dim // num_heads
         self.ffn_dim = embed_dim * ffn_ratio
 
-        norm_layer = nn.RMSNorm if use_rmsnorm else nn.LayerNorm
+        # use the ONNX-exportable `RMSNorm` only for inference/export; keep the
+        # native (fused) `nn.RMSNorm` for training performance
+        norm_layer = (RMSNorm if for_inference else nn.RMSNorm) if use_rmsnorm else nn.LayerNorm
         self.pre_attn_norm = norm_layer(embed_dim)
         self.attn = Attention(
             embed_dim,
@@ -947,6 +994,7 @@ class ParticleTransformer(nn.Module):
             scale_attn=True,
             scale_heads=True,
             scale_resids=True,
+            for_inference=for_inference,
         )
         if version > 1:
             default_cfg.update(
@@ -978,7 +1026,9 @@ class ParticleTransformer(nn.Module):
                 )
                 include_global_token = True
                 num_cls_layers = 0
-        norm_layer = nn.RMSNorm if default_cfg["use_rmsnorm"] else nn.LayerNorm
+        # use the ONNX-exportable `RMSNorm` only for inference/export; keep the
+        # native (fused) `nn.RMSNorm` for training performance
+        norm_layer = (RMSNorm if for_inference else nn.RMSNorm) if default_cfg["use_rmsnorm"] else nn.LayerNorm
 
         cfg_block = copy.deepcopy(default_cfg)
         if block_params is not None:

--- a/weaver/train.py
+++ b/weaver/train.py
@@ -434,15 +434,23 @@ def onnx(args):
         args.export_onnx = os.path.join(os.path.dirname(model_path), args.export_onnx)
     os.makedirs(os.path.dirname(args.export_onnx), exist_ok=True)
     inputs = tuple(torch.ones(model_info["input_shapes"][k], dtype=torch.float32) for k in model_info["input_names"])
-    torch.onnx.export(
-        model,
-        inputs,
-        args.export_onnx,
+    export_kwargs = dict(
         input_names=model_info["input_names"],
         output_names=model_info["output_names"],
         dynamic_axes=model_info.get("dynamic_axes", None),
         opset_version=args.onnx_opset,
     )
+    # Use the legacy TorchScript-based exporter: the models' ONNX code paths
+    # (e.g. `for_onnx` pairwise embedding, manual attention masks) are written
+    # for tracing, and the newer TorchDynamo exporter (the default since recent
+    # PyTorch versions) cannot handle their data-dependent shapes and adds an
+    # `onnxscript` dependency. The `dynamo` kwarg only exists on newer PyTorch,
+    # so set it conditionally for backward compatibility.
+    import inspect
+
+    if "dynamo" in inspect.signature(torch.onnx.export).parameters:
+        export_kwargs["dynamo"] = False
+    torch.onnx.export(model, inputs, args.export_onnx, **export_kwargs)
     _logger.info("ONNX model saved to %s", args.export_onnx)
 
     preprocessing_json = os.path.join(os.path.dirname(args.export_onnx), "preprocess.json")


### PR DESCRIPTION
The ONNX export path was broken for ParT v2/v3:

- train.py did not pin the ONNX exporter. Since PyTorch 2.9 the default flipped to the TorchDynamo exporter, which requires `onnxscript` and cannot trace ParT's data-dependent pairwise path. Pin the legacy TorchScript exporter via `dynamo=False`, set conditionally so older PyTorch (without the `dynamo` kwarg) still works.

- v3 uses `nn.RMSNorm`, which lowers to `aten::rms_norm`; the TorchScript exporter has no symbolic for it at any opset. Add an ONNX-exportable `RMSNorm` that mirrors `nn.RMSNorm` numerically and is state-dict compatible. It is used only for inference/export (selected via `for_inference`), keeping the native fused `nn.RMSNorm` for training.

Add a unit test that drives the real `weaver.train.onnx` entry point for versions 1/2/3, checks the exported graph against the PyTorch reference via onnxruntime, and verifies the train/export RMSNorm selection. The test uses an example ParT network config at test/networks/example_ParT.py.