### PR TITLE
Make exported ONNX models support dynamic batch size and sequence length

### DIFF
--- a/test/test_onnx_export.py
+++ b/test/test_onnx_export.py
@@ -56,12 +56,17 @@ def _make_args(workdir, version):
     )
 
 
-def _physical_inputs(data_config, batch=1, seed=1):
-    """Realistic inputs: non-zero (wrap-like) 4-vectors to avoid atan2(0, 0) NaNs."""
+def _physical_inputs(data_config, batch=1, seq_len=None, seed=1):
+    """Realistic inputs: non-zero (wrap-like) 4-vectors to avoid atan2(0, 0) NaNs.
+
+    `batch` and `seq_len` may differ from the configured shapes to exercise the
+    exported model's dynamic axes.
+    """
     g = torch.Generator().manual_seed(seed)
-    shapes = {k: (batch,) + s[1:] for k, s in data_config.input_shapes.items()}
+    if seq_len is None:
+        seq_len = data_config.input_shapes["pf_mask"][2]
+    shapes = {k: (batch, s[1], seq_len) for k, s in data_config.input_shapes.items()}
     inp = {k: torch.randn(*shp, generator=g) for k, shp in shapes.items()}
-    seq_len = shapes["pf_mask"][2]
     mask = torch.zeros(batch, 1, seq_len)
     for i in range(batch):
         mask[i, 0, : min(seq_len, 4 + 3 * i)] = 1
@@ -93,20 +98,22 @@ class OnnxExportTest(unittest.TestCase):
             self.assertTrue(os.path.isfile(args.export_onnx))
             self.assertTrue(os.path.isfile(os.path.join(workdir, "preprocess.json")))
 
-            # reference output from the (native-RMSNorm) PyTorch model
-            inp = _physical_inputs(data_config, batch=1)
-            with torch.no_grad():
-                logits = train_model(*[inp[k] for k in data_config.input_names])
-                ref = torch.softmax(logits, dim=1).numpy()
-
             sess = ort.InferenceSession(args.export_onnx, providers=["CPUExecutionProvider"])
-            feed = {i.name: inp[i.name].numpy().astype(np.float32) for i in sess.get_inputs()}
-            out = sess.run(None, feed)[0]
-
-        self.assertFalse(np.isnan(out).any(), msg=f"v{version}: ONNX output contains NaNs")
-        np.testing.assert_allclose(
-            out, ref, rtol=1e-3, atol=1e-4, err_msg=f"v{version}: ONNX output differs from PyTorch"
-        )
+            seq_len = data_config.input_shapes["pf_mask"][2]
+            # exercise the declared-dynamic axes: vary both batch size and
+            # sequence length away from the configured (1, seq_len) export shape
+            for batch, plen in [(1, seq_len), (4, seq_len), (1, seq_len // 2), (3, seq_len // 2)]:
+                with self.subTest(version=version, batch=batch, seq_len=plen):
+                    inp = _physical_inputs(data_config, batch=batch, seq_len=plen)
+                    with torch.no_grad():
+                        logits = train_model(*[inp[k] for k in data_config.input_names])
+                        ref = torch.softmax(logits, dim=1).numpy()
+                    feed = {i.name: inp[i.name].numpy().astype(np.float32) for i in sess.get_inputs()}
+                    out = sess.run(None, feed)[0]
+                    self.assertFalse(np.isnan(out).any(), msg=f"v{version}: ONNX output contains NaNs")
+                    np.testing.assert_allclose(
+                        out, ref, rtol=1e-3, atol=1e-4, err_msg=f"v{version}: ONNX output differs from PyTorch"
+                    )
 
     def test_export_v1(self):
         self._check_version(1)

--- a/weaver/train.py
+++ b/weaver/train.py
@@ -433,11 +433,34 @@ def onnx(args):
     if not os.path.dirname(args.export_onnx):
         args.export_onnx = os.path.join(os.path.dirname(model_path), args.export_onnx)
     os.makedirs(os.path.dirname(args.export_onnx), exist_ok=True)
-    inputs = tuple(torch.ones(model_info["input_shapes"][k], dtype=torch.float32) for k in model_info["input_names"])
+
+    # Build the dummy inputs used to trace the model. Tracing through an axis of
+    # size 1 makes the exporter specialize/bake that dimension into the graph,
+    # even when it is declared dynamic -- so the exported model would then only
+    # accept that exact size. To keep declared-dynamic axes truly dynamic, trace
+    # with size 2 for any dynamic axis whose configured size is 1 (e.g. the batch
+    # dimension, which is typically 1 in the network config's `input_shapes`).
+    dynamic_axes = model_info.get("dynamic_axes", None)
+
+    def _trace_shape(name, shape):
+        shape = list(shape)
+        axes = (dynamic_axes or {}).get(name, None)
+        if axes is not None:
+            # `dynamic_axes` entries may be a dict {axis: name} or a list [axis, ...]
+            axis_indices = axes.keys() if isinstance(axes, dict) else axes
+            for ax in axis_indices:
+                if shape[ax] == 1:
+                    shape[ax] = 2
+        return shape
+
+    inputs = tuple(
+        torch.ones(_trace_shape(k, model_info["input_shapes"][k]), dtype=torch.float32)
+        for k in model_info["input_names"]
+    )
     export_kwargs = dict(
         input_names=model_info["input_names"],
         output_names=model_info["output_names"],
-        dynamic_axes=model_info.get("dynamic_axes", None),
+        dynamic_axes=dynamic_axes,
         opset_version=args.onnx_opset,
     )
     # Use the legacy TorchScript-based exporter: the models' ONNX code paths


### PR DESCRIPTION
Tracing the model with a size-1 axis caused the ONNX exporter to specialize that dimension into the graph, even though it was declared dynamic -- so the exported model only accepted the exact (batch=1) size used at export time.

In `train.onnx`, trace with size 2 for any declared-dynamic axis whose configured size is 1 (e.g. the batch dimension, which is 1 in the network config's `input_shapes`). With this, the exported graph keeps batch size and sequence length dynamic, and runs correctly at arbitrary sizes for all model versions -- no change to the model itself is needed.

Extend the ONNX export test to run the exported model at several batch sizes and sequence lengths and check each against the PyTorch reference.